### PR TITLE
Run vogueReport after check tast

### DIFF
--- a/src/main/kotlin/com/mx/vogue/VoguePlugin.kt
+++ b/src/main/kotlin/com/mx/vogue/VoguePlugin.kt
@@ -63,7 +63,7 @@ class VoguePlugin : Plugin<Project> {
 
       // If this is configured with Coppuccino, let's add our check to the list.
       if (project.tasks.findByName("check") != null) {
-        project.tasks.getByName("check").finalizedBy("dependencyUpdates")
+        project.tasks.getByName("check").finalizedBy("vogueReport")
       }
 
       project.tasks.named("vogueReport")


### PR DESCRIPTION
# Summary of Changes

Runs `vogueReport` after the `check` task.

## Downstream Consumer Impact

Right now the `dependencyUpdates` task is being run after the `check` task; however, no report is generated or rendered.

We want to run `vogueReport` after `check` so that the user can get feedback before it shows up in the CI/CD pipeline.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
