### PR TITLE
fix: treat -rc. versions as pre-release

### DIFF
--- a/src/main/kotlin/com/mx/vogue/VoguePlugin.kt
+++ b/src/main/kotlin/com/mx/vogue/VoguePlugin.kt
@@ -58,6 +58,7 @@ class VoguePlugin : Plugin<Project> {
 
         if (dependenciesExtension.excludePreReleaseVersions) {
           it.rejectVersionIf { selection -> selection.candidate.version.lowercase().endsWith("pre") }
+          it.rejectVersionIf { selection -> selection.candidate.version.lowercase().contains("-rc.") }
         }
       }
 


### PR DESCRIPTION
Treat `-rc.` version as pre-release versions.
