### PR TITLE
fix: lock jackson dependency to current minor version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,11 @@ repositories {
   mavenCentral()
   mavenLocal()
   gradlePluginPortal()
-  maven { url "https://jitpack.io" }
 }
 
 dependencies {
   implementation "com.google.code.gson:gson:[2.0,3.0)"
-  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:[2.20,3.0)"
+  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:[2.21.0,2.22.0)"
   implementation "com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.53.0"
 
   testImplementation "org.mockito:mockito-core:[5.0,6.0)"


### PR DESCRIPTION
# Summary of Changes

Locks jackson dependency to `2.21.x` to resolve Maven Central issue with `2.22.0` not being available.

## Public API Additions/Changes

N/A

## Downstream Consumer Impact

Downstream consumers should no longer get a build error when trying to retrieve dependencies.

# How Has This Been Tested?

Pulled a snapshot version into `path-connector-hancock-whitney` and verified that dependencies can be resolved.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
